### PR TITLE
Fix menu controller mapping documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Works with **any Proton version** (Proton 9.0, Proton Experimental, Proton GE, e
 > **Note:** Tested on Batocera Linux with the unofficial Batocera add-ons Steam client.
 
 ### Usage
-Toggle menu: `F4` or `Controller Back` + `Controller Start`
+Toggle menu: `F4` or `Left Stick Click` + `Controller Start`
 
 To navigate using Controller use the `Right Stick` to move the mouse and `RB` to click.
 


### PR DESCRIPTION
The current readme displays the old show menu mapping (Pause + Back), instead of the new Left Stick Click + Pause mapping.