### PR TITLE
fix: prevent debug menu flicker when holding F1

### DIFF
--- a/src/input/Input.cpp
+++ b/src/input/Input.cpp
@@ -90,11 +90,13 @@ namespace AlphaRing::Input {
         prevButtons      = buttons;
 
         // configurable debug UI keyboard key
+        static bool debugKeyWasDown = false;
         int debugKey = g_menuConfig.debugKeyboardVKey;
-        if (GetAsyncKeyState(debugKey) & 0x8000) {
+        bool debugKeyIsDown = (GetAsyncKeyState(debugKey) & 0x8000) != 0;
+        if (debugKeyIsDown && !debugKeyWasDown) {
             AlphaRing::Global::Global()->show_imgui = !AlphaRing::Global::Global()->show_imgui;
-            return false;
         }
+        debugKeyWasDown = debugKeyIsDown;
         
         // configurable debug UI combo
         WORD debugCombo = g_menuConfig.debugComboMask;


### PR DESCRIPTION
## What changed
Fixed the debug menu rapidly toggling when F1 is held down.

## Why
Input::Update() was toggling the menu every frame while F1 was held. Added key-down edge detection so the menu only toggles once per key press.

## Testing
- Built successfully with 0 errors
- Tested the updated DLL in MCC
- Confirmed the debug menu no longer flickers when F1 is held